### PR TITLE
Update process.go to handle LinkFail events

### DIFF
--- a/process.go
+++ b/process.go
@@ -328,6 +328,12 @@ func (p *process) processHtlcEvents(stream routerrpc.Router_SubscribeHtlcEventsC
 				channel: event.IncomingChannelId,
 				htlc:    event.IncomingHtlcId,
 			}
+			
+		case *routerrpc.HtlcEvent_LinkFailEvent:
+			p.resolveChan <- circuitKey{
+				channel: event.IncomingChannelId,
+				htlc:    event.IncomingHtlcId,
+			}
 		}
 	}
 }


### PR DESCRIPTION
added "case" HtlcEvent_LinkFailEvent
regarding this issue https://github.com/lightningequipment/circuitbreaker/issues/9#issue-1402376000
works, but needs to be verified for side effects...