### PR TITLE
Take into account pending htlcs on startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.4
 	go.uber.org/zap v1.17.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.38.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/lndclient_mock.go
+++ b/lndclient_mock.go
@@ -39,6 +39,7 @@ func (l *lndclientMock) subscribeHtlcEvents(ctx context.Context,
 	routerrpc.Router_SubscribeHtlcEventsClient, error) {
 
 	return &htlcEventsMock{
+		ctx:        ctx,
 		htlcEvents: l.htlcEvents,
 	}, nil
 }
@@ -47,6 +48,7 @@ func (l *lndclientMock) htlcInterceptor(ctx context.Context) (
 	routerrpc.Router_HtlcInterceptorClient, error) {
 
 	return &htlcInterceptorMock{
+		ctx:                      ctx,
 		htlcInterceptorRequests:  l.htlcInterceptorRequests,
 		htlcInterceptorResponses: l.htlcInterceptorResponses,
 	}, nil
@@ -57,17 +59,24 @@ func (l *lndclientMock) getNodeAlias(key route.Vertex) (string, error) {
 }
 
 type htlcEventsMock struct {
+	ctx context.Context
 	routerrpc.Router_SubscribeHtlcEventsClient
 
 	htlcEvents chan *routerrpc.HtlcEvent
 }
 
 func (h *htlcEventsMock) Recv() (*routerrpc.HtlcEvent, error) {
-	event := <-h.htlcEvents
-	return event, nil
+	select {
+	case event := <-h.htlcEvents:
+		return event, nil
+
+	case <-h.ctx.Done():
+		return nil, h.ctx.Err()
+	}
 }
 
 type htlcInterceptorMock struct {
+	ctx context.Context
 	routerrpc.Router_HtlcInterceptorClient
 
 	htlcInterceptorRequests  chan *routerrpc.ForwardHtlcInterceptRequest
@@ -75,11 +84,21 @@ type htlcInterceptorMock struct {
 }
 
 func (h *htlcInterceptorMock) Send(resp *routerrpc.ForwardHtlcInterceptResponse) error {
-	h.htlcInterceptorResponses <- resp
-	return nil
+	select {
+	case h.htlcInterceptorResponses <- resp:
+		return nil
+
+	case <-h.ctx.Done():
+		return h.ctx.Err()
+	}
 }
 
 func (h *htlcInterceptorMock) Recv() (*routerrpc.ForwardHtlcInterceptRequest, error) {
-	event := <-h.htlcInterceptorRequests
-	return event, nil
+	select {
+	case event := <-h.htlcInterceptorRequests:
+		return event, nil
+
+	case <-h.ctx.Done():
+		return nil, h.ctx.Err()
+	}
 }

--- a/lndclient_mock.go
+++ b/lndclient_mock.go
@@ -58,6 +58,14 @@ func (l *lndclientMock) getNodeAlias(key route.Vertex) (string, error) {
 	return "alias-" + key.String()[:6], nil
 }
 
+func (l *lndclientMock) getPendingIncomingHtlcs(ctx context.Context) (
+	map[circuitKey]struct{}, error) {
+
+	htlcs := make(map[circuitKey]struct{})
+
+	return htlcs, nil
+}
+
 type htlcEventsMock struct {
 	ctx context.Context
 	routerrpc.Router_SubscribeHtlcEventsClient

--- a/main.go
+++ b/main.go
@@ -135,8 +135,8 @@ func main() {
 		}
 		defer client.close()
 
-		p := newProcess()
-		return p.run(context.Background(), client, config)
+		p := newProcess(client, config)
+		return p.run(context.Background())
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/peer_controller.go
+++ b/peer_controller.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+)
+
+type peerController struct {
+	htlcs   map[circuitKey]struct{}
+	cfg     *groupConfig
+	limiter *rate.Limiter
+	logger  *zap.SugaredLogger
+}
+
+func newPeerController(logger *zap.SugaredLogger, cfg *groupConfig,
+	htlcs map[circuitKey]struct{}) *peerController {
+	var limiter *rate.Limiter
+
+	// Skip if no interval set.
+	limit := rate.Inf
+	if cfg.HtlcMinInterval > 0 {
+		limit = rate.Every(cfg.HtlcMinInterval)
+	}
+	limiter = rate.NewLimiter(limit, cfg.HtlcBurstSize)
+
+	logger.Infow("Peer controller initialized",
+		"htlcMinInterval", cfg.HtlcMinInterval,
+		"htlcBurstSize", cfg.HtlcBurstSize,
+		"maxPendingHtlcs", cfg.MaxPendingHtlcs)
+
+	return &peerController{
+		cfg:     cfg,
+		htlcs:   htlcs,
+		limiter: limiter,
+		logger:  logger,
+	}
+}
+
+func (p *peerController) process(event interceptEvent) error {
+	resume := p.resume(event.circuitKey)
+
+	return event.resume(resume)
+}
+
+func (p *peerController) resume(key circuitKey) bool {
+	logger := p.keyLogger(key)
+
+	// If htlc is known, let it through. This can happen with htlcs that are
+	// already pending when circuit breaker starts.
+	if _, exists := p.htlcs[key]; exists {
+		logger.Infow("Resume replay")
+
+		return true
+	}
+
+	// Check rate limit.
+	if !p.limiter.Allow() {
+		logger.Infow("Rate limit hit")
+
+		return false
+	}
+
+	// Check max pending.
+	if p.cfg.MaxPendingHtlcs > 0 && len(p.htlcs) >= p.cfg.MaxPendingHtlcs {
+		logger.Infow("Max pending htlcs hit", "max", p.cfg.MaxPendingHtlcs)
+
+		return false
+	}
+
+	// Mark as pending.
+	p.htlcs[key] = struct{}{}
+
+	// Let through.
+	logger.Infow("Resume")
+
+	return true
+}
+
+func (p *peerController) resolved(key circuitKey) {
+	_, ok := p.htlcs[key]
+	if !ok {
+		return
+	}
+
+	delete(p.htlcs, key)
+
+	logger := p.keyLogger(key)
+	logger.Infow("Resolving htlc",
+		"pending_htlcs", len(p.htlcs),
+	)
+}
+
+func (p *peerController) keyLogger(key circuitKey) *zap.SugaredLogger {
+	return p.logger.With(
+		"htlc", key.htlc,
+		"channel", key.channel)
+}

--- a/process_test.go
+++ b/process_test.go
@@ -87,7 +87,7 @@ func testProcess(t *testing.T, event resolveEvent) {
 	<-resolved
 
 	cancel()
-	require.NoError(t, <-exit)
+	require.ErrorIs(t, <-exit, context.Canceled)
 }
 
 func TestRateLimit(t *testing.T) {
@@ -135,5 +135,5 @@ func TestRateLimit(t *testing.T) {
 	require.Equal(t, routerrpc.ResolveHoldForwardAction_FAIL, resp.Action)
 
 	cancel()
-	require.NoError(t, <-exit)
+	require.ErrorIs(t, <-exit, context.Canceled)
 }


### PR DESCRIPTION
This PR improves `circuitbreaker` by letting it take into account pending htlcs that already exist on startup.

Additionally it contains several refactors to improve code health.