### PR TITLE
Add queue mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ An example configuration can be found [here](circuitbreaker-example.yaml)
 * Execute `circuitbreaker` with the correct command line flags to connect to
   `lnd`. See `circuitbreaker --help` for details.
 
+## Queue mode
+
+There are multiple modes in which `circuitbreaker` can operate. Mode can be
+configured globally and per peer in the configuration file.
+
+* `fail`: Fail back htlcs when limits are exceeded. This minimizes the lock-up
+  of liquidity on the incoming side, but does affect your reputation as a
+  routing node.
+
+* `queue`: Queue htlcs when limits are exceeded. Items are popped from the queue
+  when the number of pending htlcs is below the maximum and the rate limit
+  allows another forward. This mode penalizes upstream nodes for the bad traffic
+  that the deliver by locking up liquidity along the route. This may push
+  upstream nodes to install a firewall too and constrain the mishaving node.
+
+* `queue_peer_initiated`: This mode is also queuing htlcs, but only those that
+  come in through channels for which we aren't the channel open initiator. Not
+  being the initiator means that the remote node is carrying the cost of a
+  potential force-closure with stuck htlcs. For channels that we initiated, the
+  safer `fail` mode is used.
+
 ## Limitations
 * This software is alpha quality. Use at your own risk and be careful in particular on mainnet.
 * The interfaces on `lnd` aren't optimized for this purpose. Therefore the use

--- a/circuitbreaker-example.yaml
+++ b/circuitbreaker-example.yaml
@@ -13,6 +13,13 @@ htlcMinInterval: 1s
 # https://en.wikipedia.org/wiki/Token_bucket.
 htlcBurstSize: 10
 
+# Default mode setting for peers. If set to 'queue', htlcs that exceed limits
+# are queued and forwarded later. If set to `queue_peer_initiated`, only htlcs
+# on channels that we didn't initiate are queued. On other channels, htlcs are
+# failed. If set to 'fail', all htlcs exceeding limits are failed back
+# instantly. If not set, mode defaults to 'fail'.
+mode: queue_peer_initiated
+
 # Define exception groups. Note that the configuration of the exception group
 # does not inherit from the defaults above. So for example not setting a rate
 # limit really means no rate limit, even if there is a default configured.

--- a/lndclient.go
+++ b/lndclient.go
@@ -94,7 +94,8 @@ func (l *lndclientGrpc) getIdentity() (route.Vertex, error) {
 }
 
 type channel struct {
-	peer route.Vertex
+	peer      route.Vertex
+	initiator bool
 }
 
 func (l *lndclientGrpc) listChannels() (map[uint64]*channel, error) {
@@ -116,7 +117,8 @@ func (l *lndclientGrpc) listChannels() (map[uint64]*channel, error) {
 		}
 
 		chans[rpcChan.ChanId] = &channel{
-			peer: peer,
+			peer:      peer,
+			initiator: rpcChan.Initiator,
 		}
 	}
 

--- a/lndclient_mock.go
+++ b/lndclient_mock.go
@@ -27,10 +27,9 @@ func (l *lndclientMock) getIdentity() (route.Vertex, error) {
 	return mockIdentity, nil
 }
 
-func (l *lndclientMock) getChanInfo(channel uint64) (*channelEdge, error) {
-	return &channelEdge{
-		node1Pub: mockIdentity,
-		node2Pub: route.Vertex{byte(channel & 0xff)},
+func (l *lndclientMock) listChannels() (map[uint64]*channel, error) {
+	return map[uint64]*channel{
+		2: {peer: route.Vertex{2}},
 	}, nil
 }
 

--- a/lndclient_mock.go
+++ b/lndclient_mock.go
@@ -30,6 +30,7 @@ func (l *lndclientMock) getIdentity() (route.Vertex, error) {
 func (l *lndclientMock) listChannels() (map[uint64]*channel, error) {
 	return map[uint64]*channel{
 		2: {peer: route.Vertex{2}},
+		3: {peer: route.Vertex{3}, initiator: true},
 	}, nil
 }
 

--- a/peer_controller.go
+++ b/peer_controller.go
@@ -1,15 +1,28 @@
 package main
 
 import (
+	"container/list"
+	"context"
+	"time"
+
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
 
 type peerController struct {
-	htlcs   map[circuitKey]struct{}
-	cfg     *groupConfig
-	limiter *rate.Limiter
-	logger  *zap.SugaredLogger
+	cfg           *groupConfig
+	limiter       *rate.Limiter
+	logger        *zap.SugaredLogger
+	interceptChan chan peerInterceptEvent
+	resolvedChan  chan circuitKey
+
+	htlcs map[circuitKey]struct{}
+}
+
+type peerInterceptEvent struct {
+	interceptEvent
+
+	peerInitiated bool
 }
 
 func newPeerController(logger *zap.SugaredLogger, cfg *groupConfig,
@@ -27,68 +40,174 @@ func newPeerController(logger *zap.SugaredLogger, cfg *groupConfig,
 	logger.Infow("Peer controller initialized",
 		"htlcMinInterval", cfg.HtlcMinInterval,
 		"htlcBurstSize", cfg.HtlcBurstSize,
-		"maxPendingHtlcs", cfg.MaxPendingHtlcs)
+		"maxPendingHtlcs", cfg.MaxPendingHtlcs,
+		"mode", cfg.Mode)
+
+	// Log initial pending htlcs.
+	for h := range htlcs {
+		logger.Infow("Initial pending htlc", h.channel, "htlc", h.htlc)
+	}
 
 	return &peerController{
-		cfg:     cfg,
-		htlcs:   htlcs,
-		limiter: limiter,
-		logger:  logger,
+		cfg:           cfg,
+		limiter:       limiter,
+		logger:        logger,
+		interceptChan: make(chan peerInterceptEvent),
+		resolvedChan:  make(chan circuitKey),
+		htlcs:         htlcs,
 	}
 }
 
-func (p *peerController) process(event interceptEvent) error {
-	resume := p.resume(event.circuitKey)
+func (p *peerController) run(ctx context.Context) error {
+	queue := list.New()
 
-	return event.resume(resume)
+	var reservation *rate.Reservation
+
+	for {
+		// New htlcs are allowed when the number of pending htlcs is below the
+		// limit, or no limit has been set.
+		newHtlcAllowed := p.cfg.MaxPendingHtlcs == 0 ||
+			len(p.htlcs) < p.cfg.MaxPendingHtlcs
+
+		// If an htlc can be forwarded, make a reservation on the rate limiter
+		// if it does not already exist.
+		if queue.Len() > 0 && newHtlcAllowed && reservation == nil {
+			reservation = p.limiter.Reserve()
+		}
+
+		// Create a delay channel based on the rate limiter delay. If there is
+		// no htlc to forward or the pending limit has been reached, use a nil
+		// channel to skip the select case.
+		var delayChan <-chan time.Time
+		if reservation != nil {
+			delayChan = time.After(reservation.Delay())
+		}
+
+		select {
+		// A new htlc is intercepted. Depending on the mode the controller is
+		// running in, the htlc will either be queued or handled immediately.
+		case event := <-p.interceptChan:
+			logger := p.keyLogger(event.circuitKey)
+
+			_, ok := p.htlcs[event.circuitKey]
+			if ok {
+				logger.Infow("Replay")
+
+				continue
+			}
+
+			if p.cfg.Mode == ModeQueue ||
+				(p.cfg.Mode == ModeQueuePeerInitiated && event.peerInitiated) {
+
+				queue.PushFront(event)
+
+				logger.Infow("Queued", "queueLen", queue.Len())
+
+				continue
+			}
+
+			if !newHtlcAllowed {
+				if err := event.resume(false); err != nil {
+					return err
+				}
+
+				logger.Infow("Failed on pending htlc limit")
+
+				continue
+			}
+
+			if !p.limiter.Allow() {
+				if err := event.resume(false); err != nil {
+					return err
+				}
+
+				logger.Infow("Failed on rate limit")
+
+				continue
+			}
+
+			if err := p.forward(event.interceptEvent); err != nil {
+				return err
+			}
+
+		// There are items in the queue, max pending htlcs has not yet been
+		// reached, and the rate limit delay has passed. Take the oldest item
+		// from the queue and forward it.
+		case <-delayChan:
+			listItem := queue.Back()
+			if listItem == nil {
+				panic("list empty")
+			}
+			queue.Remove(listItem)
+
+			event := listItem.Value.(peerInterceptEvent)
+
+			if err := p.forward(event.interceptEvent); err != nil {
+				return err
+			}
+
+			// Reservation has been used. Clear it so that a new reservation can
+			// be requested.
+			reservation = nil
+
+		// An htlc has been resolved in lnd. Remove it from the pending htlcs
+		// map to free up the slot for another htlc.
+		case key := <-p.resolvedChan:
+			_, ok := p.htlcs[key]
+			if !ok {
+				// Do not log here, because the event is still coming even for
+				// htlcs that were failed. We don't want to spam the log.
+
+				continue
+			}
+
+			delete(p.htlcs, key)
+
+			logger := p.keyLogger(key)
+			logger.Infow("Resolved htlc", "pending_htlcs", len(p.htlcs))
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
-func (p *peerController) resume(key circuitKey) bool {
-	logger := p.keyLogger(key)
+func (p *peerController) forward(event interceptEvent) error {
+	p.htlcs[event.circuitKey] = struct{}{}
 
-	// If htlc is known, let it through. This can happen with htlcs that are
-	// already pending when circuit breaker starts.
-	if _, exists := p.htlcs[key]; exists {
-		logger.Infow("Resume replay")
-
-		return true
+	err := event.resume(true)
+	if err != nil {
+		return err
 	}
 
-	// Check rate limit.
-	if !p.limiter.Allow() {
-		logger.Infow("Rate limit hit")
+	logger := p.keyLogger(event.circuitKey)
+	logger.Infow("Forwarded", "pending_htlcs", len(p.htlcs))
 
-		return false
-	}
-
-	// Check max pending.
-	if p.cfg.MaxPendingHtlcs > 0 && len(p.htlcs) >= p.cfg.MaxPendingHtlcs {
-		logger.Infow("Max pending htlcs hit", "max", p.cfg.MaxPendingHtlcs)
-
-		return false
-	}
-
-	// Mark as pending.
-	p.htlcs[key] = struct{}{}
-
-	// Let through.
-	logger.Infow("Resume")
-
-	return true
+	return nil
 }
 
-func (p *peerController) resolved(key circuitKey) {
-	_, ok := p.htlcs[key]
-	if !ok {
-		return
+func (p *peerController) process(ctx context.Context,
+	event peerInterceptEvent) error {
+
+	select {
+	case p.interceptChan <- event:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+}
 
-	delete(p.htlcs, key)
+func (p *peerController) resolved(ctx context.Context,
+	key circuitKey) error {
 
-	logger := p.keyLogger(key)
-	logger.Infow("Resolving htlc",
-		"pending_htlcs", len(p.htlcs),
-	)
+	select {
+	case p.resolvedChan <- key:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (p *peerController) keyLogger(key circuitKey) *zap.SugaredLogger {


### PR DESCRIPTION
This PR adds a new mode to `circuitbreaker` that queues htlcs rather than failing them back.

Advantages of the new mode are:
* No negative impact on your reputation as a routing node.
* Lock up liquidity upstream to nudge the nodes involved to do a better job at restricting traffic from misbehaving peers.