### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:alpine3.17 AS build-env
+
+RUN apk add --update --no-cache git
+
+COPY .  /circuitbreaker 
+
+RUN cd /circuitbreaker \
+    && rm -rf .git \
+    && go install
+RUN chmod a+x $GOPATH/bin/circuitbreaker
+
+FROM alpine:3.17
+
+LABEL org.opencontainers.image.source https://github.com/lightningequipment/circuitbreaker
+
+COPY --from=build-env /go/bin/circuitbreaker /circuitbreaker
+
+VOLUME [ "/root/.circuitbreaker" ]
+WORKDIR /
+
+ENTRYPOINT ["/circuitbreaker"]
+


### PR DESCRIPTION
This Dockerfile allows for creating an image running circuitbreaker in a container without having to install go and its dependencies first.

I have uploaded an [example image on docker-hub](https://hub.docker.com/repository/docker/aphex3k/circuitbreaker) and tested it on lnd-15.4.