### PR TITLE
add missing key for log statement

### DIFF
--- a/peer_controller.go
+++ b/peer_controller.go
@@ -45,7 +45,7 @@ func newPeerController(logger *zap.SugaredLogger, cfg *groupConfig,
 
 	// Log initial pending htlcs.
 	for h := range htlcs {
-		logger.Infow("Initial pending htlc", h.channel, "htlc", h.htlc)
+		logger.Infow("Initial pending htlc", "channel", h.channel, "htlc", h.htlc)
 	}
 
 	return &peerController{


### PR DESCRIPTION
This fixes `DPANIC        Ignored key without a value.        {"peer_alias": "xxx", "peer": "xxx", "ignored": 123}`