### PR TITLE
Increase default GRPC message size

### DIFF
--- a/db.go
+++ b/db.go
@@ -82,9 +82,9 @@ const (
 	// to prevent creation of an ever-growing table.
 	//
 	// Justification for value:
-	// * ~100 bytes per row in the table.
-	// * Help ourselves to 10MB of disk space
-	// -> 100_000 entries
+	// * ~130 bytes per row in the table.
+	// * Help ourselves to 14MB of disk space
+	// -> 100_000 entries = 13 MB, plus ~0.8MB for add_time_index.
 	defaultFwdHistoryLimit = 100_000
 )
 


### PR DESCRIPTION
Fixes #84.

Tested by running CB in stub mode, getting up to ~30k messages on master then confirming fix removes: 
<img width="778" alt="Screenshot 2023-10-23 at 1 11 54 PM" src="https://github.com/lightningequipment/circuitbreaker/assets/42311294/ee526e75-94e2-466d-b928-167bb5b3be4f">


While we're here, I've also updated the back of envelope for db defaults to be more precise (wanted to figure out the precise "worst case" disk footprint for umbrel release notes anyway).