### PR TITLE
run: always cancel context on exit

### DIFF
--- a/run.go
+++ b/run.go
@@ -37,7 +37,8 @@ const maxGrpcMsgSize = 32 * 1024 * 1024
 var content embed.FS
 
 func run(c *cli.Context) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	confDir := c.String("configdir")
 	err := os.MkdirAll(confDir, os.ModePerm)


### PR DESCRIPTION
If we exit from an error that is not in our ErrGroup, we won't cancel our top level context. This can only happen in a few places (like grpc server registration fails), but we include it for completeness.