### PR TITLE
feat: new preprocessor for HTLC events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ WORKDIR /src
 
 COPY *.go go.mod go.sum ./
 COPY circuitbreakerrpc circuitbreakerrpc/
+COPY cmd cmd/
 COPY --from=build_frontend /webui-build/ webui-build/
 
-RUN go install -ldflags "-X main.BuildVersion=$BUILD_VERSION"
+RUN go install -ldflags "-X github.com/lightningequipment/circuitbreaker.BuildVersion=$BUILD_VERSION" ./cmd/circuitbreaker/
 
 ### Build an Alpine image
 FROM alpine:3.16 as alpine

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ linux).
 
 * Clone this repository
 * `cd circuitbreaker/`
-* `go install`
+* `go install ./cmd/circuitbreaker/`
 * Execute `circuitbreaker` with the correct command line flags to connect to
   `lnd`. See `circuitbreaker --help` for details.
 * Open http://127.0.0.1:9235 in a browser.

--- a/cmd/circuitbreaker/log.go
+++ b/cmd/circuitbreaker/log.go
@@ -1,4 +1,4 @@
-package circuitbreaker
+package main
 
 import (
 	"go.uber.org/zap"

--- a/cmd/circuitbreaker/main.go
+++ b/cmd/circuitbreaker/main.go
@@ -193,6 +193,7 @@ func run(c *cli.Context) error {
 		LndStubFlag:     c.Bool(stubFlag.Name),
 		GrpcListenAddr:  c.String("listen"),
 		HttpListenAddr:  c.String(httpListenFlag.Name),
+		GetPreProcessor: cb.DefaultPreProcessorFactory,
 	}
 
 	confDir := c.String("configdir")

--- a/cmd/circuitbreaker/main.go
+++ b/cmd/circuitbreaker/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/btcsuite/btcd/btcutil"
+	cb "github.com/lightningequipment/circuitbreaker"
 	"github.com/urfave/cli"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -38,6 +44,8 @@ var (
 		Name:  "stub",
 		Usage: "set to enable stub mode (no lnd instance connected)",
 	}
+
+	errUserExit = errors.New("user requested termination")
 )
 
 // extractPathArgs parses the TLS certificate and macaroon paths from the
@@ -85,14 +93,12 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	return tlsCertPath, macPath, nil
 }
 
-var BuildVersion = "development"
-
 func main() {
 	defaultAppDir := btcutil.AppDataDir("circuitbreaker", false)
 
 	app := cli.NewApp()
 	app.Name = "circuitbreakerd"
-	app.Version = BuildVersion
+	app.Version = cb.BuildVersion
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "rpcserver",
@@ -132,7 +138,7 @@ func main() {
 		cli.Uint64Flag{
 			Name:  "fwdhistorylimit",
 			Usage: "limit the number of htlc forwards that are persisted",
-			Value: defaultFwdHistoryLimit,
+			Value: cb.DefaultFwdHistoryLimit,
 		},
 		httpListenFlag,
 		stubFlag,
@@ -174,4 +180,58 @@ func cleanAndExpandPath(path string) string {
 	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
 	// but the variables can still be expanded via POSIX-style $VARIABLE.
 	return filepath.Clean(os.ExpandEnv(path))
+}
+
+// run is the main entry point for the circuitbreaker application from the CLI.
+// It parses the configuration and starts the main application.
+func run(c *cli.Context) error {
+	log.Infow("Circuit Breaker starting", "version", cb.BuildVersion)
+	log.Sync()
+
+	cfg := cb.RunConfig{
+		FwdHistoryLimit: c.Int("fwdhistorylimit"),
+		LndStubFlag:     c.Bool(stubFlag.Name),
+		GrpcListenAddr:  c.String("listen"),
+		HttpListenAddr:  c.String(httpListenFlag.Name),
+	}
+
+	confDir := c.String("configdir")
+	err := os.MkdirAll(confDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	cfg.DbPath = filepath.Join(confDir, dbFn)
+
+	if !cfg.LndStubFlag {
+		// First, we'll parse the args from the command.
+		cfg.LndTlsCertPath, cfg.LndMacaroonPath, err = extractPathArgs(c)
+		if err != nil {
+			return err
+		}
+		cfg.LndRpcServer = c.GlobalString("rpcserver")
+	}
+
+	group, ctx := errgroup.WithContext(context.Background())
+
+	// Run main application.
+	group.Go(func() error {
+		return cb.Run(ctx, &cfg)
+	})
+
+	group.Go(func() error {
+		log.Infof("Press ctrl-c to exit")
+
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case <-sigint:
+			return errUserExit
+
+		case <-ctx.Done():
+			return nil
+		}
+	})
+
+	return group.Wait()
 }

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 type Mode int
 

--- a/db.go
+++ b/db.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"
@@ -78,14 +78,14 @@ var migrations = &migrate.MemoryMigrationSource{
 }
 
 const (
-	// defaultFwdHistoryLimit is the default limit we place on the forwarding_history table
+	// DefaultFwdHistoryLimit is the default limit we place on the forwarding_history table
 	// to prevent creation of an ever-growing table.
 	//
 	// Justification for value:
 	// * ~130 bytes per row in the table.
 	// * Help ourselves to 14MB of disk space
 	// -> 100_000 entries = 13 MB, plus ~0.8MB for add_time_index.
-	defaultFwdHistoryLimit = 100_000
+	DefaultFwdHistoryLimit = 100_000
 )
 
 var defaultNodeKey = route.Vertex{}

--- a/db_test.go
+++ b/db_test.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"
@@ -24,7 +24,7 @@ func setupTestDb(t *testing.T, fwdingHistoryLimit int) (*Db, func()) {
 
 func TestDb(t *testing.T) {
 	ctx := context.Background()
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	expectedDefaultLimit := Limit{

--- a/lndclient.go
+++ b/lndclient.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"

--- a/lndclient.go
+++ b/lndclient.go
@@ -105,9 +105,11 @@ type lndHtlcInterceptorClient struct {
 }
 
 type interceptedEvent struct {
-	circuitKey   circuitKey
-	incomingMsat lnwire.MilliSatoshi
-	outgoingMsat lnwire.MilliSatoshi
+	circuitKey      circuitKey
+	incomingMsat    lnwire.MilliSatoshi
+	outgoingMsat    lnwire.MilliSatoshi
+	outgoingReqChan uint64
+	paymentHash     []byte
 }
 
 func (h *lndHtlcInterceptorClient) recv() (*interceptedEvent, error) {
@@ -121,8 +123,10 @@ func (h *lndHtlcInterceptorClient) recv() (*interceptedEvent, error) {
 			channel: event.IncomingCircuitKey.ChanId,
 			htlc:    event.IncomingCircuitKey.HtlcId,
 		},
-		incomingMsat: lnwire.MilliSatoshi(event.IncomingAmountMsat),
-		outgoingMsat: lnwire.MilliSatoshi(event.OutgoingAmountMsat),
+		incomingMsat:    lnwire.MilliSatoshi(event.IncomingAmountMsat),
+		outgoingMsat:    lnwire.MilliSatoshi(event.OutgoingAmountMsat),
+		outgoingReqChan: event.OutgoingRequestedChanId,
+		paymentHash:     event.PaymentHash,
 	}, nil
 }
 

--- a/lndclient_mock.go
+++ b/lndclient_mock.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var (
 func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	network := strings.ToLower(ctx.GlobalString("network"))
 	switch network {
-	case "mainnet", "testnet", "regtest", "simnet":
+	case "mainnet", "testnet", "regtest", "simnet", "signet", "testnet4":
 	default:
 		return "", "", fmt.Errorf("unknown network: %v", network)
 	}

--- a/peer_controller.go
+++ b/peer_controller.go
@@ -72,6 +72,8 @@ type peerController struct {
 	lnd             lndclient
 	now             func() time.Time
 	htlcCompleted   func(context.Context, *HtlcInfo) error
+
+	preProcessor PreProcessor
 }
 
 type inFlightHtlc struct {
@@ -112,6 +114,7 @@ type peerControllerCfg struct {
 	pubKey        route.Vertex
 	now           func() time.Time
 	htlcCompleted func(context.Context, *HtlcInfo) error
+	preProcessor  PreProcessor
 }
 
 func newPeerController(cfg *peerControllerCfg) *peerController {
@@ -152,6 +155,7 @@ func newPeerController(cfg *peerControllerCfg) *peerController {
 		lastChannelSync: cfg.now(),
 		now:             cfg.now,
 		htlcCompleted:   cfg.htlcCompleted,
+		preProcessor:    cfg.preProcessor,
 	}
 }
 

--- a/peer_controller.go
+++ b/peer_controller.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"container/list"

--- a/peer_controller.go
+++ b/peer_controller.go
@@ -298,6 +298,16 @@ func (p *peerController) run(ctx context.Context) error {
 				continue
 			}
 
+			// Call the preprocessor. If it rejects the HTLC, fail it immediately.
+			if !p.preProcessor(ctx, event) {
+				logger.Infow("HTLC rejected by preprocessor")
+				if err := event.resume(false); err != nil {
+					return err
+				}
+				p.incrCounter(eventReject)
+				continue
+			}
+
 			mode := p.cfg.Mode
 
 			switch {

--- a/preprocess.go
+++ b/preprocess.go
@@ -1,0 +1,47 @@
+package circuitbreaker
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// PreProcessorFactory is a function that creates a PreProcessor for a given node.
+type PreProcessorFactory func(route.Vertex) PreProcessor
+
+// PreProcessor is a function that preprocesses intercepted HTLC events.
+// If it returns false, the HTLC is rejected immediately. Otherwise, it is processed
+// normally by the circuitbreaker.
+type PreProcessor func(ctx context.Context, event InterceptEvent) bool
+
+// InterceptEvent represents an intercepted HTLC event.
+type InterceptEvent interface {
+	// The id of the channel that is part of the incoming circuit.
+	GetIncomingChanID() uint64
+
+	// The index of the incoming htlc in the incoming channel.
+	GetIncomingHtlcId() uint64
+
+	// The incoming HTLC amount.
+	GetIncomingMsat() uint64
+
+	// The requested outgoing channel id for this forwarded HTLC. Because of
+	// non-strict forwarding, this isn't necessarily the channel over which the
+	// packet will be forwarded eventually. A different channel to the same
+	// peer may be selected as well.
+	GetOutgoingReqChanID() uint64
+
+	// The outgoing HTLC amount.
+	GetOutgoingMsat() uint64
+
+	// The HTLC payment hash. This value is not guaranteed to be unique per request.
+	GetPaymentHash() []byte
+}
+
+// DefaultPreProcessorFactory returns a PreProcessor that accepts all HTLCs.
+func DefaultPreProcessorFactory(nodePub route.Vertex) PreProcessor {
+	return func(ctx context.Context, event InterceptEvent) bool {
+		// By default, we accept all HTLCs.
+		return true
+	}
+}

--- a/process.go
+++ b/process.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"

--- a/process.go
+++ b/process.go
@@ -45,10 +45,39 @@ type circuitKey struct {
 
 type interceptEvent struct {
 	circuitKey
-	incomingMsat lnwire.MilliSatoshi
-	outgoingMsat lnwire.MilliSatoshi
-	resume       func(bool) error
+	incomingMsat    lnwire.MilliSatoshi
+	outgoingMsat    lnwire.MilliSatoshi
+	outgoingReqChan uint64
+	paymentHash     []byte
+	resume          func(bool) error
 }
+
+func (e interceptEvent) GetIncomingChanID() uint64 {
+	return e.channel
+}
+
+func (e interceptEvent) GetIncomingHtlcId() uint64 {
+	return e.htlc
+}
+
+func (e interceptEvent) GetIncomingMsat() uint64 {
+	return uint64(e.incomingMsat)
+}
+
+func (e interceptEvent) GetOutgoingReqChanID() uint64 {
+	return e.outgoingReqChan
+}
+
+func (e interceptEvent) GetOutgoingMsat() uint64 {
+	return uint64(e.outgoingMsat)
+}
+
+func (e interceptEvent) GetPaymentHash() []byte {
+	return e.paymentHash
+}
+
+// compile time check that interceptEvent implements InterceptEvent interface.
+var _ InterceptEvent = (*interceptEvent)(nil)
 
 type resolvedEvent struct {
 	incomingCircuitKey circuitKey
@@ -514,10 +543,12 @@ func (p *process) processInterceptor(ctx context.Context,
 
 		select {
 		case p.interceptChan <- interceptEvent{
-			circuitKey:   key,
-			incomingMsat: event.incomingMsat,
-			outgoingMsat: event.outgoingMsat,
-			resume:       resume,
+			circuitKey:      key,
+			incomingMsat:    event.incomingMsat,
+			outgoingMsat:    event.outgoingMsat,
+			outgoingReqChan: event.outgoingReqChan,
+			paymentHash:     event.paymentHash,
+			resume:          resume,
 		}:
 
 		case <-ctx.Done():

--- a/process.go
+++ b/process.go
@@ -88,9 +88,13 @@ type process struct {
 
 	// Testing hook
 	resolvedCallback func()
+
+	getPreProcessor PreProcessorFactory
 }
 
-func NewProcess(client lndclient, log *zap.SugaredLogger, limits *Limits, db *Db) *process {
+func NewProcess(client lndclient, log *zap.SugaredLogger, limits *Limits, db *Db,
+	getPreProcessor PreProcessorFactory) *process {
+
 	return &process{
 		db:                      db,
 		log:                     log,
@@ -106,6 +110,7 @@ func NewProcess(client lndclient, log *zap.SugaredLogger, limits *Limits, db *Db
 		limits:                  limits,
 		burstSize:               burstSize,
 		peerRefreshInterval:     defaultPeerRefreshInterval,
+		getPreProcessor:         getPreProcessor,
 	}
 }
 
@@ -272,6 +277,7 @@ func (p *process) createPeerController(ctx context.Context, peer route.Vertex,
 
 			return p.db.RecordHtlcResolution(ctx, htlc)
 		},
+		preProcessor: p.getPreProcessor(peer),
 	}
 	ctrl := newPeerController(cfg)
 

--- a/process_test.go
+++ b/process_test.go
@@ -560,3 +560,55 @@ func TestClosedChannelHtlc(t *testing.T) {
 	cancel()
 	require.ErrorIs(t, <-exit, context.Canceled)
 }
+
+// TestPreProcessorReject tests that the PreProcessor can reject HTLCs.
+func TestPreProcessorReject(t *testing.T) {
+	defer Timeout()()
+
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
+	defer cleanup()
+
+	cfg := &Limits{
+		Default: Limit{
+			MaxHourlyRate: 3600, // High enough to not trigger rate limit
+			MaxPending:    10,   // High enough to not trigger pending limit
+			Mode:          ModeFail,
+		},
+	}
+
+	client := newLndclientMock(testChannels, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := zaptest.NewLogger(t).Sugar()
+
+	// Create a PreProcessor that rejects all HTLCs
+	rejectingPreProcessor := func(nodePub route.Vertex) PreProcessor {
+		return func(ctx context.Context, event InterceptEvent) bool {
+			// Reject all HTLCs
+			return false
+		}
+	}
+
+	p := NewProcess(client, log, cfg, db, rejectingPreProcessor)
+
+	exit := make(chan error)
+	go func() {
+		exit <- p.Run(ctx)
+	}()
+
+	key := circuitKey{
+		channel: 2,
+		htlc:    5,
+	}
+	client.htlcInterceptorRequests <- &interceptedEvent{
+		circuitKey: key,
+	}
+
+	// HTLC should be rejected by the PreProcessor
+	resp := <-client.htlcInterceptorResponses
+	require.False(t, resp.resume)
+
+	cancel()
+	require.ErrorIs(t, <-exit, context.Canceled)
+}

--- a/process_test.go
+++ b/process_test.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"
@@ -37,7 +37,7 @@ func testProcess(t *testing.T, event resolveEvent) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	log := zaptest.NewLogger(t).Sugar()
@@ -114,7 +114,7 @@ func TestLimits(t *testing.T) {
 func testRateLimit(t *testing.T, mode Mode) {
 	defer Timeout()()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	cfg := &Limits{
@@ -204,7 +204,7 @@ func testRateLimit(t *testing.T, mode Mode) {
 func testMaxPending(t *testing.T, mode Mode) {
 	defer Timeout()()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	cfg := &Limits{
@@ -283,7 +283,7 @@ func TestNewPeer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	log := zaptest.NewLogger(t).Sugar()
@@ -323,7 +323,7 @@ func TestNewPeer(t *testing.T) {
 func TestBlocked(t *testing.T) {
 	defer Timeout()()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	cfg := &Limits{
@@ -375,7 +375,7 @@ func TestChannelNotFound(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	log := zaptest.NewLogger(t).Sugar()
@@ -459,7 +459,7 @@ func testLookupOutgoingChannel(t *testing.T, settled, outgoingFound bool,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	log := zaptest.NewLogger(t).Sugar()
@@ -529,7 +529,7 @@ func TestClosedChannelHtlc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, cleanup := setupTestDb(t, defaultFwdHistoryLimit)
+	db, cleanup := setupTestDb(t, DefaultFwdHistoryLimit)
 	defer cleanup()
 
 	log := zaptest.NewLogger(t).Sugar()

--- a/process_test.go
+++ b/process_test.go
@@ -55,7 +55,7 @@ func testProcess(t *testing.T, event resolveEvent) {
 		},
 	}
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	resolved := make(chan struct{})
 	p.resolvedCallback = func() {
@@ -136,7 +136,7 @@ func testRateLimit(t *testing.T, mode Mode) {
 
 	log := zaptest.NewLogger(t).Sugar()
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 	p.burstSize = 2
 
 	exit := make(chan error)
@@ -228,7 +228,7 @@ func testMaxPending(t *testing.T, mode Mode) {
 
 	log := zaptest.NewLogger(t).Sugar()
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 	p.burstSize = 2
 
 	exit := make(chan error)
@@ -290,7 +290,7 @@ func TestNewPeer(t *testing.T) {
 
 	cfg := &Limits{}
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	// Setup quick peer refresh.
 	p.peerRefreshInterval = 100 * time.Millisecond
@@ -341,7 +341,7 @@ func TestBlocked(t *testing.T) {
 
 	log := zaptest.NewLogger(t).Sugar()
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	exit := make(chan error)
 	go func() {
@@ -382,7 +382,7 @@ func TestChannelNotFound(t *testing.T) {
 
 	cfg := &Limits{}
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	exit := make(chan error)
 
@@ -466,7 +466,7 @@ func testLookupOutgoingChannel(t *testing.T, settled, outgoingFound bool,
 
 	cfg := &Limits{}
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	resolved := make(chan struct{})
 	p.resolvedCallback = func() {
@@ -536,7 +536,7 @@ func TestClosedChannelHtlc(t *testing.T) {
 
 	cfg := &Limits{}
 
-	p := NewProcess(client, log, cfg, db)
+	p := NewProcess(client, log, cfg, db, DefaultPreProcessorFactory)
 
 	exit := make(chan error)
 

--- a/run.go
+++ b/run.go
@@ -1,29 +1,22 @@
-package main
+package circuitbreaker
 
 import (
 	"context"
 	"embed"
-	"errors"
 	"io/fs"
 	"net"
 	"net/http"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"syscall"
 	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningequipment/circuitbreaker/circuitbreakerrpc"
-	"github.com/urfave/cli"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 )
-
-var errUserExit = errors.New("user requested termination")
 
 // maxGrpcMsgSize is used when we configure both server and clients to allow sending and
 // receiving at most 32 MB GRPC messages.
@@ -36,52 +29,58 @@ const maxGrpcMsgSize = 32 * 1024 * 1024
 //go:embed all:webui-build
 var content embed.FS
 
-func run(c *cli.Context) error {
-	ctx := context.Background()
+type RunConfig struct {
+	DbPath          string
+	FwdHistoryLimit int
+	LndStubFlag     bool
+	LndRpcServer    string
+	LndTlsCertPath  string
+	LndMacaroonPath string
+	Logger          *zap.SugaredLogger
+	GrpcListenAddr  string
+	HttpListenAddr  string
+}
 
-	confDir := c.String("configdir")
-	err := os.MkdirAll(confDir, os.ModePerm)
-	if err != nil {
-		return err
+// Run starts the main application logic using the provided configuration.
+func Run(ctx context.Context, c *RunConfig) error {
+	var logger *zap.SugaredLogger
+
+	// if no logger is provided, use default global one
+	if c.Logger == nil {
+		logger = log
+	} else {
+		logger = c.Logger
+		// overwrite global logger with provided one
+		log = c.Logger
 	}
-	dbPath := filepath.Join(confDir, dbFn)
+	logger.Infow("Opening database", "path", c.DbPath)
 
-	log.Infow("Circuit Breaker starting", "version", BuildVersion)
-
-	log.Infow("Opening database", "path", dbPath)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// Open database.
-	db, err := NewDb(ctx, dbPath, c.Int("fwdhistorylimit"))
+	db, err := NewDb(ctx, c.DbPath, c.FwdHistoryLimit)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		err := db.Close()
 		if err != nil {
-			log.Errorw("Error closing db", "err", err)
+			logger.Errorw("Error closing db", "err", err)
 		}
 	}()
 
-	group, ctx := errgroup.WithContext(ctx)
-
-	stub := c.Bool(stubFlag.Name)
 	var client lndclient
-	if stub {
+	if c.LndStubFlag {
 		stubClient := newStubClient(ctx)
 
 		client = stubClient
 	} else {
-		// First, we'll parse the args from the command.
-		tlsCertPath, macPath, err := extractPathArgs(c)
-		if err != nil {
-			return err
-		}
-
 		lndCfg := LndConfig{
-			RpcServer:   c.GlobalString("rpcserver"),
-			TlsCertPath: tlsCertPath,
-			MacPath:     macPath,
-			Log:         log,
+			RpcServer:   c.LndRpcServer,
+			TlsCertPath: c.LndTlsCertPath,
+			MacPath:     c.LndMacaroonPath,
+			Log:         logger,
 		}
 
 		lndClient, err := NewLndClient(&lndCfg)
@@ -98,7 +97,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	p := NewProcess(client, log, limits, db)
+	p := NewProcess(client, logger, limits, db)
 
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(maxGrpcMsgSize),
@@ -108,14 +107,12 @@ func run(c *cli.Context) error {
 
 	reflection.Register(grpcServer)
 
-	server := NewServer(log, p, client, db)
+	server := NewServer(logger, p, client, db)
 
 	circuitbreakerrpc.RegisterServiceServer(
 		grpcServer, server,
 	)
-
-	listenAddress := c.String("listen")
-	grpcInternalListener, err := net.Listen("tcp", listenAddress)
+	grpcInternalListener, err := net.Listen("tcp", c.GrpcListenAddr)
 	if err != nil {
 		return err
 	}
@@ -124,7 +121,7 @@ func run(c *cli.Context) error {
 	// This is where the gRPC-Gateway proxies the requests
 	conn, err := grpc.DialContext(
 		ctx,
-		listenAddress,
+		c.GrpcListenAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(maxGrpcMsgSize),
@@ -144,7 +141,7 @@ func run(c *cli.Context) error {
 
 	serverRoot, err := fs.Sub(content, "webui-build")
 	if err != nil {
-		log.Fatal(err)
+		logger.Fatal(err)
 	}
 
 	fs := http.FileServer(http.FS(serverRoot))
@@ -152,12 +149,13 @@ func run(c *cli.Context) error {
 	mux.Handle("/api/", http.StripPrefix("/api", gwmux))
 	mux.HandleFunc("/", fs.ServeHTTP)
 
-	httpListen := c.String(httpListenFlag.Name)
 	gwServer := &http.Server{
-		Addr:              httpListen,
+		Addr:              c.HttpListenAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: time.Second * 10,
 	}
+
+	group, ctx := errgroup.WithContext(ctx)
 
 	// Run circuitbreaker core.
 	group.Go(func() error {
@@ -166,10 +164,10 @@ func run(c *cli.Context) error {
 
 	// Run grpc server.
 	group.Go(func() error {
-		log.Infow("Grpc server starting", "listenAddress", listenAddress)
+		logger.Infow("Grpc server starting", "listenAddress", c.GrpcListenAddr)
 		err := grpcServer.Serve(grpcInternalListener)
 		if err != nil && err != grpc.ErrServerStopped {
-			log.Errorw("grpc server error", "err", err)
+			logger.Errorw("grpc server error", "err", err)
 		}
 
 		return err
@@ -177,7 +175,7 @@ func run(c *cli.Context) error {
 
 	// Run http server.
 	group.Go(func() error {
-		log.Infow("HTTP server starting", "listenAddress", httpListen)
+		logger.Infow("HTTP server starting", "listenAddress", c.HttpListenAddr)
 
 		return gwServer.ListenAndServe()
 	})
@@ -187,32 +185,17 @@ func run(c *cli.Context) error {
 		<-ctx.Done()
 
 		// Stop http server.
-		log.Infof("Stopping http server")
+		logger.Infof("Stopping http server")
 		err := gwServer.Shutdown(context.Background()) //nolint:contextcheck
 		if err != nil {
-			log.Errorw("Error shutting down http server", "err", err)
+			logger.Errorw("Error shutting down http server", "err", err)
 		}
 
 		// Stop grpc server.
-		log.Infof("Stopping grpc server")
+		logger.Infof("Stopping grpc server")
 		grpcServer.Stop()
 
 		return nil
-	})
-
-	group.Go(func() error {
-		log.Infof("Press ctrl-c to exit")
-
-		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-
-		select {
-		case <-sigint:
-			return errUserExit
-
-		case <-ctx.Done():
-			return nil
-		}
 	})
 
 	return group.Wait()

--- a/run.go
+++ b/run.go
@@ -121,6 +121,8 @@ func Run(ctx context.Context, c *RunConfig) error {
 	if err != nil {
 		return err
 	}
+	// Clean up listener if we exit before grpc server starts.
+	defer grpcInternalListener.Close()
 
 	// Create a client connection to the gRPC server we just started
 	// This is where the gRPC-Gateway proxies the requests
@@ -135,6 +137,11 @@ func Run(ctx context.Context, c *RunConfig) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logger.Errorw("Error closing grpc client connection", "err", err)
+		}
+	}()
 
 	// Create http server.
 	gwmux := runtime.NewServeMux()

--- a/run.go
+++ b/run.go
@@ -39,18 +39,19 @@ type RunConfig struct {
 	Logger          *zap.SugaredLogger
 	GrpcListenAddr  string
 	HttpListenAddr  string
+	GetPreProcessor PreProcessorFactory
 }
 
 // Run starts the main application logic using the provided configuration.
 func Run(ctx context.Context, c *RunConfig) error {
 	var logger *zap.SugaredLogger
 
-	// if no logger is provided, use default global one
+	// If no logger is provided, use default global one
 	if c.Logger == nil {
 		logger = log
 	} else {
 		logger = c.Logger
-		// overwrite global logger with provided one
+		// Overwrite global logger with provided one
 		log = c.Logger
 	}
 	logger.Infow("Opening database", "path", c.DbPath)
@@ -97,7 +98,11 @@ func Run(ctx context.Context, c *RunConfig) error {
 		return err
 	}
 
-	p := NewProcess(client, logger, limits, db)
+	factory := c.GetPreProcessor
+	if factory == nil {
+		factory = DefaultPreProcessorFactory
+	}
+	p := NewProcess(client, logger, limits, db, factory)
 
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(maxGrpcMsgSize),

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"
@@ -12,6 +12,8 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 	"go.uber.org/zap"
 )
+
+var BuildVersion = "development"
 
 type server struct {
 	process *process

--- a/stub.go
+++ b/stub.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"context"

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,4 +1,4 @@
-package main
+package circuitbreaker
 
 import (
 	"os"


### PR DESCRIPTION
Hey @carlaKC , hey @joostjager 

I wanted to add the ability to define additional limits for HTLCs (e.g. #68) without changing the CB too much. The simplest approach seemed to be to inject this logic into the CB via a hook that is executed before the CB’s internal limits are evaluated.

This required a refactoring so that the CB can be run both as a CLI and embedded in another process.